### PR TITLE
la till ny customer post type för butiker

### DIFF
--- a/wp-content/themes/storefront-child/functions.php
+++ b/wp-content/themes/storefront-child/functions.php
@@ -2,6 +2,9 @@
 
 function grupp_projekt_post_types(){
     register_post_type('butik', array(
+        'supports' => array('title', 'editor', 'excerpt', 'custom-fields'),
+        'rewrite' => array('slug', 'butiker'),
+        'has_archive' => true,
         'public' => true,
         'show_in_rest' => true,
         'labels' => array(

--- a/wp-content/themes/storefront-child/functions.php
+++ b/wp-content/themes/storefront-child/functions.php
@@ -1,0 +1,21 @@
+<?php
+
+function grupp_projekt_post_types(){
+    register_post_type('butik', array(
+        'public' => true,
+        'show_in_rest' => true,
+        'labels' => array(
+            'name' => 'Butiker',
+            'add_new_item' => 'Lägg till ny butik',
+            'edit_item' => 'Editera butik',
+            'all_items' => 'Butiker',
+            'singular_name' => 'Butik',
+        ),
+        'menu_icon' => 'dashicons-store'
+        )
+    );
+    }
+
+add_action('init', 'grupp_projekt_post_types')
+
+?>


### PR DESCRIPTION
La till en ny custom post type för butiker enligt uppgiften:

7. Det skall finnas en sida som listar företagets fysiska butiker.  
 - Butikerna skall skapas med hjälp av en egenskapad Custom Post Type (anpassad posttyp). 

Den läggs till i functions.php filen som finns under child-temat till store-front. 
Man kan välja att bryta ut den här filen till annan plats egentligen. Men vi kan göra det sedan om vi vill. Vi kan också skapa en single-butik.php mallsida för just när en butik ska visas och så. men det blir i en annan pr och någon annan kan även göra det om man känner för det.

